### PR TITLE
Fix typo in Second Variety: now->new

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -3,8 +3,8 @@
 	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
 		<dc:identifier id="uid">url:https://standardebooks.org/ebooks/philip-k-dick/short-fiction</dc:identifier>
 		<dc:date>2015-11-27T21:53:59Z</dc:date>
-		<meta property="dcterms:modified">2017-10-19T03:29:28Z</meta>
-		<meta property="se:revision-number">25</meta>
+		<meta property="dcterms:modified">2017-11-18T19:03:19Z</meta>
+		<meta property="se:revision-number">26</meta>
 		<dc:rights>The source text and artwork in this ebook edition are believed to be in the U.S. public domain. This ebook edition is released under the terms in the CC0 1.0 Universal Public Domain Dedication, available at https://creativecommons.org/publicdomain/zero/1.0/. For full license information see the Uncopyright file included at the end of this ebook.</dc:rights>
 		<dc:publisher id="publisher">Standard Ebooks</dc:publisher>
 		<meta property="file-as" refines="#publisher">Standard Ebooks</meta>

--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -32,7 +32,7 @@
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>This is the <span class="revision-number">26th</span> edition of this ebook.<br/>
 			This edition was released on<br/>
-			<span class="revision-date">November 18, 2017, 07:03 <abbr class="time eoc">p.m.</abbr></span><br/>
+			<span class="revision-date">November 18, 2017, 7:03 <abbr class="time eoc">p.m.</abbr></span><br/>
 			The first edition was released on<br/>
 			<span class="release-date">November 27, 2015, 9:53 <abbr class="time eoc">p.m.</abbr></span><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>

--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -30,9 +30,9 @@
 			<span epub:type="se:name.visual-art.typeface">League Spartan</span> and <span epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</span><br/>
 			typefaces created in 2014 and 2009 by<br/>
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
-			<p>This is the <span class="revision-number">25th</span> edition of this ebook.<br/>
+			<p>This is the <span class="revision-number">26th</span> edition of this ebook.<br/>
 			This edition was released on<br/>
-			<span class="revision-date">October 19, 2017, 3:29 <abbr class="time eoc">a.m.</abbr></span><br/>
+			<span class="revision-date">November 18, 2017, 07:03 <abbr class="time eoc">p.m.</abbr></span><br/>
 			The first edition was released on<br/>
 			<span class="release-date">November 27, 2015, 9:53 <abbr class="time eoc">p.m.</abbr></span><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>

--- a/src/epub/text/second-variety.xhtml
+++ b/src/epub/text/second-variety.xhtml
@@ -303,7 +303,7 @@
 			<p>“We’ll pull you under if anything happens,” Klaus said.</p>
 			<p>“Thanks.” Hendricks waited a moment, resting the transmitter against his shoulder. “Interesting, isn’t it?”</p>
 			<p>“What?”</p>
-			<p>“This, the new types. The new varieties of claws. We’re completely at their mercy, aren’t we? By now they’ve probably gotten into the <abbr class="initialism">UN</abbr> lines, too. It makes me wonder if we’re not seeing the beginning of a now species. <em>The</em> new species. Evolution. The race to come after man.”</p>
+			<p>“This, the new types. The new varieties of claws. We’re completely at their mercy, aren’t we? By now they’ve probably gotten into the <abbr class="initialism">UN</abbr> lines, too. It makes me wonder if we’re not seeing the beginning of a new species. <em>The</em> new species. Evolution. The race to come after man.”</p>
 			<hr/>
 			<p>Rudi grunted. “There is no race after man.”</p>
 			<p>“No? Why not? Maybe we’re seeing it now, the end of human beings, the beginning of the new society.”</p>


### PR DESCRIPTION
Small typo in "Second Variety". Compare to scan [here](https://archive.org/stream/Space_Science_Fiction_v01n06_1953-05_UnkSc-cape1736#page/n121/mode/2up). Looks like there was a small ink smear or a blur in the scan that made the o look like an e.